### PR TITLE
Fix Browserless context in sub workflow

### DIFF
--- a/Login_e_ObterToken_ConsultaPDPJ.json
+++ b/Login_e_ObterToken_ConsultaPDPJ.json
@@ -22,33 +22,6 @@
     },
     {
       "parameters": {
-        "method": "POST",
-        "url": "https://chrome.browserless.io/function?token=2SPBwNmoXs9lAWleb18afef9c8ea33a8d4534967cd2bc1888",
-        "sendBody": true,
-        "contentType": "raw",
-        "rawContentType": "application/json",
-        "body": "{   \"code\": \"export default async function({ page, context }) { /* …seu código… */ }\",   \"context\": {     \"numero_processo\": \"={{$node[\\\"Set Número Processo\\\"].json[\\\"numero_processo\\\"]}}\"   } }",
-        "options": {
-          "response": {
-            "response": {
-              "responseFormat": "json"
-            }
-          },
-          "timeout": 600000
-        }
-      },
-      "id": "583f9606-19bc-4505-81c1-61950376bb54",
-      "name": "Login & Obter access_token e Consultar PDPJ",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4,
-      "position": [
-        920,
-        220
-      ],
-      "onError": "continueRegularOutput"
-    },
-    {
-      "parameters": {
         "jsCode": "const { success, error, dados_processo } = $json;\nif (!success) {\n  throw new Error(`Erro no Browserless (login/consulta): ${error}`);\n}\nreturn [{ json: dados_processo }];"
       },
       "id": "13483d6c-ed1c-4232-a22d-7909fc4f9c3f",
@@ -64,8 +37,8 @@
       "parameters": {
         "resource": "Browser Rest Apis",
         "operation": "Execute",
-        "code": "export default async function({ page, context }) {\n  const usuario = '06293234456';\n  const senha = 'Simb@280303';\n  const numero = context.numero_processo;\n  try {\n    await page.setViewport({ width: 1920, height: 1080 });\n    await page.setUserAgent(\n      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +\n      'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'\n    );\n\n    await page.goto('https://pje.cloud.tjpe.jus.br/1g/login.seam', {\n      waitUntil: 'networkidle2',\n      timeout: 60000\n    });\n    await page.waitForSelector('#username', { visible: true, timeout: 30000 });\n    await page.waitForSelector('#password', { visible: true, timeout: 30000 });\n    await page.type('#username', usuario, { delay: 50 });\n    await page.type('#password', senha, { delay: 50 });\n    await page.click('#kc-login');\n    await page.waitForNavigation({ waitUntil: 'networkidle2', timeout: 60000 });\n\n    await page.waitForTimeout(2000);\n    await page.goto('https://portaldeservicos.pdpj.jus.br/consulta', {\n      waitUntil: 'networkidle2',\n      timeout: 60000\n    });\n    await page.waitForTimeout(2000);\n\n    const jwt = await page.evaluate(() => localStorage.getItem('access_token'));\n    if (!jwt) {\n      return {\n        data: { error: 'access_token não encontrado em localStorage.' },\n        type: 'application/json'\n      };\n    }\n\n    const consultaUrl = `https://portaldeservicos.pdpj.jus.br/api/v2/processos/${numero}`;\n    const resposta = await page.evaluate(\n      async ({ url, token }) => {\n        const resp = await fetch(url, {\n          method: 'GET',\n          headers: {\n            'Authorization': `Bearer ${token}`,\n            'Accept': 'application/json'\n          }\n        });\n        if (!resp.ok) {\n          const txt = await resp.text();\n          throw new Error(`Erro na API PDPJ: ${resp.status} - ${txt}`);\n        }\n        return resp.json();\n      },\n      { url: consultaUrl, token: jwt }\n    );\n\n    return {\n      data: resposta,\n      type: 'application/json'\n    };\n  } catch (err) {\n    return {\n      data: { error: err.message },\n      type: 'application/json'\n    };\n  }\n}",
-        "context": "={{$node[\"Set_Numero_Processo\"].json[\"numero_processo\"]}}\n",
+        "code": "export default async function({ page, context }) {\n  const usuario = context.usuario;\n  const senha = context.senha;\n  const numero = context.numero_processo;\n  try {\n    await page.setViewport({ width: 1920, height: 1080 });\n    await page.setUserAgent(\n      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +\n      'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'\n    );\n\n    await page.goto('https://pje.cloud.tjpe.jus.br/1g/login.seam', {\n      waitUntil: 'networkidle2',\n      timeout: 60000\n    });\n    await page.waitForSelector('#username', { visible: true, timeout: 30000 });\n    await page.waitForSelector('#password', { visible: true, timeout: 30000 });\n    await page.type('#username', usuario, { delay: 50 });\n    await page.type('#password', senha, { delay: 50 });\n    await page.click('#kc-login');\n    await page.waitForNavigation({ waitUntil: 'networkidle2', timeout: 60000 });\n\n    await page.waitForTimeout(2000);\n    await page.goto('https://portaldeservicos.pdpj.jus.br/consulta', {\n      waitUntil: 'networkidle2',\n      timeout: 60000\n    });\n    await page.waitForTimeout(2000);\n\n    const jwt = await page.evaluate(() => localStorage.getItem('access_token'));\n    if (!jwt) {\n      return {\n        data: { error: 'access_token não encontrado em localStorage.' },\n        type: 'application/json'\n      };\n    }\n\n    const consultaUrl = `https://portaldeservicos.pdpj.jus.br/api/v2/processos/${numero}`;\n    const resposta = await page.evaluate(\n      async ({ url, token }) => {\n        const resp = await fetch(url, {\n          method: 'GET',\n          headers: {\n            'Authorization': `Bearer ${token}`,\n            'Accept': 'application/json'\n          }\n        });\n        if (!resp.ok) {\n          const txt = await resp.text();\n          throw new Error(`Erro na API PDPJ: ${resp.status} - ${txt}`);\n        }\n        return resp.json();\n      },\n      { url: consultaUrl, token: jwt }\n    );\n\n    return {\n      data: resposta,\n      type: 'application/json'\n    };\n  } catch (err) {\n    return {\n      data: { error: err.message },\n      type: 'application/json'\n    };\n  }\n}\n",
+        "context": "={{jsonEncode({numero_processo: $node[\"Set_Numero_Processo\"].json[\"numero_processo\"], usuario: $env.PJE_USER, senha: $env.PJE_PASSWORD})}}",
         "timeout": 300000,
         "blockAds": false,
         "requestOptions": {}
@@ -127,11 +100,6 @@
             "index": 0
           }
         ]
-      ]
-    },
-    "Login & Obter access_token e Consultar PDPJ": {
-      "main": [
-        []
       ]
     },
     "Set_Numero_Processo": {

--- a/My_workflow_9 (3).json
+++ b/My_workflow_9 (3).json
@@ -241,33 +241,6 @@
     },
     {
       "parameters": {
-        "workflowId": {
-          "__rl": true,
-          "value": "kqp62gO6DyoNRXKq",
-          "mode": "list",
-          "cachedResultName": "My Sub-Workflow 1"
-        },
-        "workflowInputs": {
-          "mappingMode": "defineBelow",
-          "value": {},
-          "matchingColumns": [],
-          "schema": [],
-          "attemptToConvertTypes": false,
-          "convertFieldsToString": true
-        },
-        "options": {}
-      },
-      "type": "n8n-nodes-base.executeWorkflow",
-      "typeVersion": 1.2,
-      "position": [
-        240,
-        600
-      ],
-      "id": "594871b1-693b-4d1c-99da-ea3a55668ff8",
-      "name": "Execute Workflow"
-    },
-    {
-      "parameters": {
         "description": "Ferramenta que faz login automático no PJe (TJPE) via Browserless/Puppeteer, extrai o token de acesso (access_token) armazenado em localStorage e executa, em sequência, uma requisição à API do PDPJ para consultar os dados completos de um processo judicial.\n\nO que ela faz:\n1. Navega até https://pje.cloud.tjpe.jus.br/1g/login.seam, preenche CPF e senha e efetua login via Keycloak.\n2. Após autenticar, acessa https://portaldeservicos.pdpj.jus.br/consulta para que o front-end salve o access_token no localStorage.\n3. Lê o valor de localStorage.getItem('access_token') e, em seguida, faz um fetch GET para https://portaldeservicos.pdpj.jus.br/api/v2/processos/{numero_processo}, passando Authorization: Bearer <access_token> no cabeçalho.\n4. Devolve o JSON completo do processo (classe, partes, movimentações, valores, etc.) para o fluxo pai.\n\nParâmetro obrigatório:\n- numero_processo (string): número do processo judicial no formato CNJ (20 dígitos ou NNNNNNN-DD.AAAA.J.TT.OOOO).\n\nRetorno:\n- Em caso de sucesso: todo o objeto JSON com os dados do processo (campo dados_processo).\n- Em caso de falha: objeto { \"success\": false, \"error\": \"<mensagem de erro detalhada>\" }, que será transformado em erro no nó seguinte.\n\nQuando usar:\nSempre que o usuário solicitar consulta de um processo no chat, para garantir que o login e a chamada à API sejam feitos de forma segura e unificada, sem necessidade de intervenções manuais.",
         "workflowId": {
           "__rl": true,


### PR DESCRIPTION
## Summary
- clean up unused nodes in workflow JSON
- secure Browserless login by reading credentials from env vars

## Testing
- `jq '.' Login_e_ObterToken_ConsultaPDPJ.json`
- `jq '.' 'My_workflow_9 (3).json'`


------
https://chatgpt.com/codex/tasks/task_e_683f95b7ffac832cb9908844cd7428dd