### PR TITLE
Fix workflow trigger typeVersion

### DIFF
--- a/Login_e_ObterToken_ConsultaPDPJ.json
+++ b/Login_e_ObterToken_ConsultaPDPJ.json
@@ -12,7 +12,7 @@
         }
       },
       "id": "c055762a-8fe7-4141-a639-df2372f30060",
-      "typeVersion": 1.1,
+      "typeVersion": 1,
       "name": "When Executed by Another Workflow",
       "type": "n8n-nodes-base.executeWorkflowTrigger",
       "position": [


### PR DESCRIPTION
## Summary
- fix the numeric value for `typeVersion` in `Login_e_ObterToken_ConsultaPDPJ.json`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406540827c832e83263d387b657b3f